### PR TITLE
man: Add the missing XKB_DEFAULT_ options and clarify.

### DIFF
--- a/loliwm.1
+++ b/loliwm.1
@@ -33,9 +33,10 @@ will use \fBweston-terminal\fP.
 .IP \fBXKB_DEFAULT_LAYOUT\fR
 Sets the keyboard layout such as \fBgb\fP for UK layout.
 .IP \fBXKB_DEFAULT_OPTIONS\fR
-Sets the keyboard options such as \fBcompose:ralt,ctrl:nocaps\fP.
-.IP \fBXKB_DEFAULT_LAYOUT\fR
-.IP \fBXKB_DEFAULT_LAYOUT\fR
+Sets the keyboard options, each seperated by a comma, for example:
+\fBcompose:ralt,ctrl:nocaps\fP.
+.IP \fBXKB_DEFAULT_VARIANT\fR
+.IP \fBXKB_DEFAULT_RULES\fR
+.IP \fBXKB_DEFAULT_MODEL\fR
 .SH AUTHORS
 .IP "Jari Vetoniemi <http://cloudef.pw/>"
-


### PR DESCRIPTION
Attempts to clarify the usage of `XKB_DEFAULT_OPTIONS` as it may be non-obvious at first that the syntax is exactly the same as within `xorg.conf`.
