### PR TITLE
man: Add documentation for fullscreen toggle.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,11 @@ Note that these keybinds are temporary until configuration is added.
 +-----------------+------------------------------------------------------+
 | ``mod-k``       | Rotates focus through outputs.                       |
 +-----------------+------------------------------------------------------+
+| ``mod-f``       | Toggles fullscreen.                                  |
++-----------------+------------------------------------------------------+
 | ``mod-[1..n]``  | Activate space.                                      |
 +-----------------+------------------------------------------------------+
-| ``mod-F1..F10`` | Moves focused client to                              |
-|                 | corresponding space.                                 |
+| ``mod-F1..F10`` | Moves focused client to corresponding space.         |
 +-----------------+------------------------------------------------------+
 | ``mod-z, x, c`` | Moves focused client to output 1, 2 and 3            |
 |                 | respectively.                                        |

--- a/loliwm.1
+++ b/loliwm.1
@@ -28,17 +28,19 @@ Force EGL clients to fallback on shm.
 .SH KEYBINDINGS
 N.B. These are a tentative set of keybindings created specifically to provide
 basic usage until more flexible mechanisms are added.
-.IP \fBmod\-return\fR
+.IP \fBmod-return\fR
 Opens a new terminal emulator client.
 .IP \fBmod-p\fR
 Opens \fBbemenu-run\fR (similar to \fBdmenu_run\fR) for starting applications.
-.IP \fBmod\-l\fR
+.IP \fBmod-l\fR
 Rotates focus through clients.
-.IP \fBmod\-k\fR
+.IP \fBmod-k\fR
 Rotates focus through available outputs.
-.IP \fBmod\-[1..n]\fR
+.IP \fBmod-f\fR
+Toggles fullscreen for the focused client.
+.IP \fBmod-[1..n]\fR
 Selects the \fInth\fP workspace, currently limited to ten.
-.IP \fBmod\-F1..F10\fR
+.IP \fBmod-F1..F10\fR
 Moves the focused client to the corresponding workspace.
 .IP "\fBmod-z, x, c\fR"
 Moves focused client to outputs 1, 2 and 3 respectively.


### PR DESCRIPTION
This also simplifies the manual just a bit (needless escapes).
