### PR TITLE
Rename git submodule to be easier to set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
    path = lib/inihck
    url = git://github.com/Cloudef/inihck.git
    branch = master
-[submodule "lib/chck"]
+[submodule "chck"]
    path = lib/chck
    url = git://github.com/Cloudef/chck.git
    branch = master


### PR DESCRIPTION
This makes the AUR package use the correct path, and probably helps other users as well.